### PR TITLE
Add Openwork to AI Web automation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Tools that convert natural language prompts into web interactions, allowing AI a
 - **[Skyvern-AI](https://github.com/Skyvern-AI/skyvern)** - control a web browser through natural language instructions using **visual** language models - Open-source
 - **[Tarsier](https://github.com/reworkd/tarsier)** by Reworkd - Open-source
 - **[Browser-use](https://github.com/gregpr07/browser-use)** Interface between LLM and browser to execute high-level instructions - like applying for jobs
+- **[Openwork](https://github.com/accomplish-ai/openwork)** - MIT-licensed, open alternative to Anthropic's Cowork with multi-LLM support for browser automation - Open-source
 
 ### Paid Platforms
 


### PR DESCRIPTION
## Summary
- Adds [Openwork](https://github.com/accomplish-ai/openwork) to the AI Web automation tools (Open Source) section

## About Openwork
Openwork is an MIT-licensed, open alternative to Anthropic's Cowork, built using [Opencode](https://github.com/anomalyco/opencode) and [dev-browser](https://github.com/SawyerHood/dev-browser). It supports multiple LLM providers and lets users launch computer-use agents to automate real browser workflows—faster, safer, and fully open source.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)