### PR TITLE
Add BrowserTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Tools and SDKs that power web automation with AI.
 
 ---
 
+## 🧭 Debugging & Trace Viewers
+
+Tools for inspecting and sharing AI browser-agent runs.
+
+- **[BrowserTrace](https://github.com/aaronlab/browsertrace)** — Local-first trace viewer for AI browser agents. Records screenshots, URLs, actions, model I/O, status, and errors; exports redacted standalone HTML traces. Open-source.
+
+---
+
 ## 🏢 Enterprise System Automation Packages
 
 Pre-built, open-source browser automation for enterprise platforms. Powered by Puppeteer and [Anchor Browser](https://anchorbrowser.io) cloud. Published as `@browser-automation-hub/*` npm packages.


### PR DESCRIPTION
Adds BrowserTrace as a focused debugging/trace-viewer tool for AI browser agents.

Why it fits this list:
- BrowserTrace is built for Browser Use, Stagehand, Skyvern, Playwright + LLM scripts, and custom browser-agent workflows.
- It records screenshots, URLs, actions, model I/O, status, and errors locally.
- It can export redacted standalone HTML traces for sharing failures without exposing private agent data.

Validation:
- BrowserTrace repo URL returns HTTP 200.
- `git diff --check` passes.

Note: I also tried `npx -y awesome-lint README.md`, but the current repository baseline reports existing style/lint issues across the file, so I did not treat that as a blocker for this narrow entry.