### PR TITLE
Add invisible-playwright to Browsers for AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cloud-hosted and open-source browsers designed for AI agents.
 - **[Browserbase](https://www.browserbase.com/)** — Cloud browser platform with session replay, stealth mode, and Playwright/Puppeteer support. Paid.
 - **[Browserless](https://www.browserless.io/)** — Scalable headless Chrome in the cloud. Paid.
 - **[APIFY](https://apify.com/)** — Browser automation + web scraping platform. Paid.
+- **[invisible-playwright](https://github.com/feder-cr/invisible_playwright)** — Open-source patched Firefox 150 + Playwright wrapper. Source-level fingerprint spoofing via C++ patches against mozilla-central. Passes reCAPTCHA v3 and FingerprintPro without JS-level overrides. Self-hostable. MIT (wrapper) + MPL-2.0 (patches).
 
 ---
 


### PR DESCRIPTION
Open-source browser distribution for AI agents that need anti-detect web access. Patched Firefox 150 source built into a binary, distributed as a Playwright wrapper so agents can drive it through the standard Playwright API.

Different angle from the cloud entries already in this section: self-hosted, no SaaS, source patches published. Companion patches repo at https://github.com/feder-cr/firefox-stealth lists the 15 patch layers (Canvas 2D, GPU/WebGL, Fonts, Audio, WebRTC, Timezone, DevTools detection, SOCKS5 auth, etc).

Repo: https://github.com/feder-cr/invisible_playwright