### PR TITLE
feat: add TWZRD Agent Intel to Web Authentication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Model Context Protocol servers that give LLMs (Claude, GPT-4, etc.) direct brows
 Tools that enable AI agents to access authenticated websites and sessions.
 
 - **[Anchor Browser](https://anchorbrowser.io/)** — Built-in MFA handling, cookie/session persistence, and fingerprint management for agents.
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — On-chain wallet identity verification for AI agents on Solana. MCP tools verify agent trust score before x402 micropayments. Free: `score_agent(wallet)`, `preflight_check(wallet)`.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Web Authentication section.

Where traditional web authentication tools handle session cookies and MFA, TWZRD handles the newer challenge of **agent wallet identity** — verifying that an AI agent's Solana wallet is legitimate before x402 micropayments.

**Free MCP Tools:**
- `score_agent(wallet)` — on-chain trust score and reputation history
- `preflight_check(wallet)` — verify agent identity before payment

**MCP Config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Complements the existing Anchor Browser entry by handling the on-chain identity layer rather than the session/cookie layer.