### PR TITLE
Add Agent QA to web automation frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Tools and SDKs that power web automation with AI.
 - **[Tarsier](https://github.com/reworkd/tarsier)** by Reworkd — Vision utilities for web agents (element tagging, OCR).
 - **[Notte](https://notte.cc/)** — Framework for building web agents with planning, vision, and LLM reasoning.
 
+### Source-available
+
+- **[Agent QA](https://github.com/vostride/agent-qa)** — Authors and runs natural-language web application regression tests with deterministic checks, optional LLM-based grading, and reviewable run evidence. FSL-1.1-ALv2; each release converts to Apache-2.0 after two years.
+
 ### Paid Platforms
 
 - **[Axiom.ai](https://axiom.ai/)** — No-code browser automation bots. Paid.


### PR DESCRIPTION
## Summary

- Add a Source-available subsection to AI Web Automation Frameworks.
- List Agent QA with its documented natural-language web regression testing, deterministic checks, optional LLM-based grading, and reviewable run evidence.
- State the current FSL-1.1-ALv2 license and two-year Apache-2.0 conversion so it is not misclassified under Open Source.

## Validation

- `git diff --check`
- Confirmed the canonical Agent QA URL is unique in the README and publicly accessible.
- Searched repository code, issues, and pull requests for an existing Agent QA entry immediately before submission.

## Disclosure

I am affiliated with Agent QA and Vostride and am proposing this listing on the project's behalf.
