### PR TITLE
Add browser-bridge to Web Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Model Context Protocol servers that give LLMs (Claude, GPT-4, etc.) direct brows
 Tools that enable AI agents to access authenticated websites and sessions.
 
 - **[Anchor Browser](https://anchorbrowser.io/)** — Built-in MFA handling, cookie/session persistence, and fingerprint management for agents.
+- **[browser-bridge](https://github.com/1clawAI/browser-bridge)** — Governed credential fill: the bridge logs into sites in a page the agent never scripts, so the agent drives authenticated sessions without ever seeing the password. Also handles sign-up and API-key capture. Open source (Apache-2.0), speaks CDP, exposes MCP tools.
 
 ---
 


### PR DESCRIPTION
Adds **[browser-bridge](https://github.com/1clawAI/browser-bridge)** (Apache-2.0, open source) under Web Authentication.

It lets an AI agent access authenticated sites without ever seeing the credential: the agent drives the browser normally, and when a login is needed the bridge types the password into a page the agent never scripts, so it never enters the agent's context. It also handles governed sign-up and reading a site-issued API key into a vault. Speaks CDP and exposes MCP tools.

Placed right after the existing entry, matching the section's format.